### PR TITLE
Implement correct XDG Base Directory fallback

### DIFF
--- a/dr14tmeter/dr14_config.py
+++ b/dr14tmeter/dr14_config.py
@@ -29,8 +29,13 @@ else:
 
 def get_config_directory( create = True ):
     
-    cfg_dir = "%s/.config/dr14tmeter" % os.path.expanduser("~")
-    
+    p = os.environ.get('XDG_CONFIG_HOME')
+
+    if p is None or not os.path.isabs(p):
+        p = os.path.expanduser('~/.config')
+
+    cfg_dir = os.path.join(p, 'dr14tmeter')
+
     if not os.path.isdir(cfg_dir) and create :
         os.mkdir( cfg_dir )
     


### PR DESCRIPTION
This patch properly checks the `XDG_CONFIG_HOME` environment before falling back on the `HOME/.config` alternative.

It solves the issue where my system does not use `HOME/.config` but relies on the XBDS (XDG Base Directory Specification) to relocate configurations `HOME/local/cfg` instead.
