### PR TITLE
add option which skips version check

### DIFF
--- a/dr14tmeter/dr14_tmeter.py
+++ b/dr14tmeter/dr14_tmeter.py
@@ -122,8 +122,9 @@ def main():
     if options.quiet :
         set_quiet_msg()
 
-    l_ver = TestVer()
-    l_ver.start()
+    if not options.quiet and not options.skip_version_check:
+        l_ver = TestVer()
+        l_ver.start()
     
     print_msg( path_name )
     print_msg( "" )

--- a/dr14tmeter/parse_args.py
+++ b/dr14tmeter/parse_args.py
@@ -149,6 +149,11 @@ def parse_args():
         action="store_true",
         dest="quiet",
         help="Quiet mode")
+
+    parser.add_argument("--skip_version_check",
+        action="store_true",
+        dest="skip_version_check",
+        help="Do not check for new versions")
     
     parser.add_argument( "-v" , "--version" ,
         action="store_true",


### PR DESCRIPTION
`--skip_version_check`
More or less resolves #31

Also, what about making it disabled by default?