### PR TITLE
Added support for custom environment configuration

### DIFF
--- a/dr14_tmeter
+++ b/dr14_tmeter
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # dr14_t.meter: compute the DR14 value of the given audiofiles
 #Copyright (C) 2011  Simone Riva


### PR DESCRIPTION
This fix allows execution of `dr14_tmeter` using non standard python paths, for instance
if you have different python environments managed by conda.