### PR TITLE
Fix --dr_database arg being store_false, not store_true

### DIFF
--- a/dr14tmeter/parse_args.py
+++ b/dr14tmeter/parse_args.py
@@ -97,7 +97,7 @@ def parse_args():
                                              [-q help] """ )
 
     parser.add_argument("-d", "--dr_database",
-                        action="store_false",
+                        action="store_true",
                         dest="dr_database",
                         help="Output file compatible with the DR database at http:///www.dr.loudness-war.info")
 


### PR DESCRIPTION
#29

`-d, --dr_database` command-line argument is intended to turn _on_ [Loudness War Database](http://dr.loudness-war.info/) compatibility. But it has `store_false`, inverting its logic (compatibility is turned _off_ when `-d` specified).

https://github.com/simon-r/dr14_t.meter/blob/ecb431d9a504f9d5d8710303d60ab80a1219ab07/dr14tmeter/parse_args.py#L99-L102

Checked, in `master` it outputs _compatible_ logs without `-d` (in compatible logs, title block is single-line, not two lines, one for artist and one for album).

After this patch:

```
~/items/dr14_t.meter % ./dr14_tmeter -r ~/Music/l/Lacrimosa/1991\ Angst
...

~/items/dr14_t.meter % head -n 6 ~/Music/l/Lacrimosa/1991\ Angst/dr14.txt
----------------------------------------------------------------------------------------------
 Album: Angst
 Artist: Lacrimosa
----------------------------------------------------------------------------------------------
DR	Peak	RMS	Duration	Title [codec]
----------------------------------------------------------------------------------------------
```
```
~/items/dr14_t.meter % ./dr14_tmeter -d -r ~/Music/l/Lacrimosa/1991\ Angst
...

~/items/dr14_t.meter % head -n 6 ~/Music/l/Lacrimosa/1991\ Angst/dr14.txt
----------------------------------------------------------------------------------------------
 Analyzed: Angst /  Artist: Lacrimosa
----------------------------------------------------------------------------------------------
DR	Peak	RMS	Duration	Title [codec]
----------------------------------------------------------------------------------------------
 DR13	 -1.37 dB	 -17.49 dB	9:25	01 - Seele in Not 	 [mp3]
```