### PR TITLE
Add --tag option to write DR to the tags of files scanned.

### DIFF
--- a/dr14tmeter/dr14_global.py
+++ b/dr14tmeter/dr14_global.py
@@ -175,6 +175,15 @@ def test_matplotlib_modules(fun_name):
 
     return True
 
+def test_mutagen(fun_name):
+    try:
+        import mutagen
+    except ImportError:
+        print_msg(
+            "The %s function require the installation of MatPlotLib: http://matplotlib.sourceforge.net" % fun_name)
+        return False
+
+    return True
 
 def test_hist_modules():
     try:

--- a/dr14tmeter/dr14_utils.py
+++ b/dr14tmeter/dr14_utils.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from dr14tmeter.tagger import Tagger
 import multiprocessing
 import os
 import tempfile
@@ -54,6 +55,11 @@ def scan_files_list(input_file, options, out_dir):
         success = False
     else:
         write_results(dr, options, out_dir, "")
+
+    if options.tag:
+        tagger = Tagger()
+        tagger.write_dr_tags(dr)
+
         success = True
 
     clock = time.time() - a
@@ -78,6 +84,10 @@ def scan_dir_list(subdirlist, options, out_dir):
         else:
             cpu = get_thread_cnt()
             r = dr.scan_mp(cur_dir, cpu)
+
+        if options.tag:
+            tagger = Tagger()
+            tagger.write_dr_tags(dr)
 
         if r == 0:
             continue

--- a/dr14tmeter/parse_args.py
+++ b/dr14tmeter/parse_args.py
@@ -159,6 +159,11 @@ def parse_args():
                         dest="version",
                         help="print the current version and exit")
 
+    parser.add_argument("--tag", 
+                        action="store_true",
+                        dest="tag",
+                        help="Write the DR to the tag of the input files")
+
     parser.add_argument(
         dest="path_name",
         nargs='?',

--- a/dr14tmeter/tagger.py
+++ b/dr14tmeter/tagger.py
@@ -1,0 +1,92 @@
+# dr14_t.meter: compute the DR14 value of the given audiofiles
+# Copyright (C) 2011  Simone Riva
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from dr14tmeter import dr14_global
+import os
+from mutagen.mp3 import MP3
+from mutagen.flac import FLAC
+from mutagen.oggvorbis import OggVorbis
+from mutagen.oggopus import OggOpus
+from mutagen.monkeysaudio import MonkeysAudio
+from mutagen.mp4 import MP4
+from mutagen.id3 import ID3, TXXX
+from dr14tmeter.audio_file_reader import *
+
+
+class Tagger:
+
+    def __init__(self):
+        self.formats = ['.flac', '.mp3', '.ogg', '.opus', '.mp4',
+                        '.m4a', '.wav', '.ape', '.ac3', '.wma']
+        self.dir_name = ''
+        self._ext = -1
+    
+    def write_dr_tags(self, dr):
+
+        if not dr14_global.test_mutagen("Tagging"):
+            sys.exit(1)
+
+        self.dir_name = dr.dir_name
+        
+        for item in dr.res_list:
+            self.read_track_new(item)
+
+    def get_file_ext_code(self):
+        return self._ext
+
+    def read_track_new(self, item):
+
+        (f, ext) = os.path.splitext(item['file_name'])
+        ext = ext.lower()
+
+        if ext not in self.formats:
+            return False
+
+        audio = None
+        filename = self.dir_name + os.sep + item['file_name']
+
+        if ext == '.mp3':
+            audio = MP3(filename)
+            audio.add_tags
+        elif ext == '.flac':
+            audio = FLAC(filename)
+        elif ext == '.ogg':
+            audio = OggVorbis(filename)
+        elif ext == '.opus':
+            audio = OggOpus(filename)
+        elif ext in ['.mp4', '.m4a']:
+            audio = MP4(filename)
+        elif ext == '.wav':
+            raise Exception("Tagging .wav files not supported")
+        elif ext == '.ape':
+            audio = MonkeysAudio(filename)
+        elif ext == '.ac3':
+            raise Exception("Tagging .ac3 files not supported")
+        elif ext == '.wma':
+            raise Exception("Tagging .wma files not supported")
+        else:
+            return False
+
+        if isinstance(audio, MP3):
+            audio.tags.add(TXXX(encoding=3, desc=u"DR", text=[str(item["dr14"])]))
+        else:
+            audio["DR"] = [str(item["dr14"])]
+        
+        audio.save()
+        
+        self._ext = self.formats.index(ext)
+
+        return True

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,4 @@ setup(name = "dr14_tmeter",
         'Programming Language :: Python',
         'Topic :: Multimedia'] ,
     cmdclass={"install": dr14_install },
-    install_requires=['numpy'],
 ) 


### PR DESCRIPTION
This adds the mutagen tagging library as a dependency.  All input files are supported except WMA, AC3, and WAV.

Note that not all music players support extended tags. Deadbeef and foobar2000 should support the DR tag on all supported formats, and quod libet should support the DR tag on all formats except MP3.

If your music player supports custom columns, you can now sort by dynamic range score!
![Screenshot from 2021-06-26 20-24-38](https://user-images.githubusercontent.com/11930112/123530133-c3141100-d6bc-11eb-8565-73fe2277d966.png)
