### PR TITLE
use a DR value including the filename

### DIFF
--- a/dr14tmeter/dr14_utils.py
+++ b/dr14tmeter/dr14_utils.py
@@ -156,7 +156,7 @@ def write_results(dr, options, out_dir, cur_dir):
 
     tables_list = {
         'b': ["dr14_bbcode.txt", BBcodeTable()],
-        't': ["dr14.txt", TextTable()],
+        't': ["dr14-DR"+str(dr.dr14)+".txt",TextTable()],
         'h': ["dr14.html", HtmlTable()],
         'w': ["dr14_mediawiki.txt", MediaWikiTable()]
     }


### PR DESCRIPTION
I find it much easier to see the calculated DR by adding it to the dr14.txt resulting in dr14-DRxx.txt instead of opening the file itself.

This is just for .txt

Signed-off-by: Richard Fröhning <misanthropos@gmx.de>